### PR TITLE
Build & Release Automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,5 @@ jobs:
           java-version: '17'
           build-extra-args: '-x :modules:ai-tasks-rest-test:build'
           profile: 'prod'
-          upload-bundle: true
-          upload-artifacts: true
-          retention-days: '1'
-      - name: Download Built Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts--jdk-17
-      - name: Download Built Bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: bundle--jdk-17
-      - name: Verify Artifacts
-        run: ls -la
+          upload-bundle: false
+          upload-artifacts: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           workspace-directory: ./liferay-workspace
           java-version: '17'
+          build-extra-args: '-x :modules:ai-tasks-rest-test:build'
           profile: 'prod'
           upload-bundle: true
           upload-artifacts: true
@@ -24,4 +25,10 @@ jobs:
         with:
           name: artifacts--jdk-17
       - name: Verify Artifacts
+        run: ls -la
+      - name: Download Built Bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle--jdk-17
+      - name: Verify Bundle
         run: ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: artifacts--jdk-17
-      - name: Verify Artifacts
-        run: ls -la
       - name: Download Built Bundle
         uses: actions/download-artifact@v4
         with:
           name: bundle--jdk-17
-      - name: Verify Bundle
+      - name: Verify Artifacts
         run: ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build Liferay Workspace
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build Workspace
+        uses: lgdd/liferay-build-action@v1
+        with:
+          workspace-directory: ./liferay-workspace
+          java-version: '17'
+          profile: 'prod'
+          upload-bundle: true
+          upload-artifacts: true
+          retention-days: '1'
+      - name: Download Built Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+      - name: Verify Artifacts
+        run: ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build Workspace
-        uses: lgdd/liferay-build-action@v1
+        uses: lgdd/liferay-build-action@v2
         with:
           workspace-directory: ./liferay-workspace
           java-version: '17'
@@ -22,6 +22,6 @@ jobs:
       - name: Download Built Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: artifacts--jdk-17
       - name: Verify Artifacts
         run: ls -la

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release Liferay Bundle & Modules
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: simple
+  upload-release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lgdd/liferay-build-action@v2
+        with:
+          java-version: '17'
+          build-extra-args: '-x :modules:ai-tasks-rest-test:build'
+          profile: 'prod'
+          upload-bundle: true
+          upload-artifacts: true
+          retention-days: '1'
+      - name: Download Built Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts--jdk-17
+      - name: Download Built Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle--jdk-17
+      - name: Upload Release Files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rm -rf dist
+          mkdir -p dist/client-extensions
+          mkdir -p dist/modules
+          cp ai-tasks-*.zip dist/client-extensions/
+          cp fi.soveltia.liferay.aitasks.*.jar dist/modules/
+          cd dist/
+          zip -r ai-tasks-widgets--jdk17.zip client-extensions/ modules/
+          mv ai-tasks-widgets--jdk17.zip ../
+          cd ../
+          mv liferay-workspace-prod-*.zip ai-tasks-liferay-bundle--jdk17.zip
+          gh release upload ${{ needs.release-please.outputs.tag_name }} ai-tasks-widgets--jdk17.zip ai-tasks-liferay-bundle--jdk17.zip


### PR DESCRIPTION
Added **2 GitHub Action Workflows**:

- Automatic workspace build on push and pull requests
- Automatic release using [Google Release Please](https://github.com/googleapis/release-please?tab=readme-ov-file) which follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

For the release, the repository settings under `Actions > General` should have `Read and write permissions` checked and `Allow GitHub Actions to create and approve pull requests` checked as well.

The way the release please action works is to have an open pull request all the time with the right version number of the release based on the conventional commit history of everything merged on the min branch. Once we're happy with the state of a main branch and we want to publish a release, all we have to do is merge the pull request created by the release please action. You can find an example with [this repo](https://github.com/lgdd/map-for-objects).

The uploaded file in a release are in the following formats:
```
ai-tasks-widgets--jdk17.zip
ai-tasks-liferay-bundle--jdk17.zip
```
> The first archive contains both client extensions and modules under their respective folders as they can be found under the `osgi` directory of a Liferay bundle.
> The second archive is a Liferay bundle built from the prod configuration.
> Both have a suffix with the Java version used for that build to allow multiple Java versions build in the future.

Complete #4 