### PR TITLE
fix(admin-web): json edit of node parameters

### DIFF
--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/AnthropicChatModelNodeConfigureForm.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/AnthropicChatModelNodeConfigureForm.js
@@ -1,12 +1,20 @@
 /**
  * @author Petteri Karttunen
+ * @author Louis-Guillaume Durand
  */
 import React from 'react';
+
+import { JsonEditor } from 'json-edit-react';
 
 import { Tab, Tabs } from '../../ui/Tabs';
 
 const AnthropicChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
-  const rangeWidth = (nodeParameters.temperature / 2) * 100;
+  const rangeWidth = nodeParameters.temperature * 100;
+
+  const handleToolsChange = ({ newData }) => {
+    onChange('tools', newData);
+  };
+
   return (
     <Tabs>
       <Tab id={'generalSettings'} label={'General Settings'}>
@@ -272,14 +280,15 @@ const AnthropicChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
         <div>
           <div className="form-group">
             <label htmlFor="tools">Tools</label>
-            <textarea
-              className="form-control"
-              id="tools"
-              rows="20"
-              value={JSON.stringify(nodeParameters.tools, undefined, 2)}
-              onChange={(e) => {
-                onChange('tools', JSON.parse(e.currentTarget.value));
-              }}
+            <JsonEditor
+              data={nodeParameters.tools || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleToolsChange}
+              onAdd={handleToolsChange}
+              onDelete={handleToolsChange}
             />
             <small className="form-text text-muted">Tools configuration as JSON.</small>
           </div>
@@ -338,7 +347,7 @@ const AnthropicChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
                     onChange('cacheSystemMessages', e.currentTarget.checked);
                   }}
                 />
-                <span class="custom-control-label">Cache system messages.</span>
+                <span className="custom-control-label">Cache system messages.</span>
               </label>
             </div>
             <div className="custom-control custom-checkbox custom-control-outside">
@@ -354,7 +363,7 @@ const AnthropicChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
                     onChange('cacheTools', e.currentTarget.checked);
                   }}
                 />
-                <span class="custom-control-label">Cache tools.</span>
+                <span className="custom-control-label">Cache tools.</span>
               </label>
             </div>
           </div>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/GeminiChatModelNodeConfigureForm.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/GeminiChatModelNodeConfigureForm.js
@@ -4,10 +4,17 @@
  */
 import React from 'react';
 
+import { JsonEditor } from 'json-edit-react';
+
 import { Tab, Tabs } from '../../ui/Tabs';
 
 const GeminiChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
   const rangeWidth = nodeParameters.temperature * 100;
+
+  const handleToolsChange = ({ newData }) => {
+    onChange('tools', newData);
+  };
+
   return (
     <Tabs>
       <Tab id={'generalSettings'} label={'General Settings'}>
@@ -256,14 +263,15 @@ const GeminiChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
         <div>
           <div className="form-group">
             <label htmlFor="tools">Tools</label>
-            <textarea
-              className="form-control"
-              id="tools"
-              rows="20"
-              value={JSON.stringify(nodeParameters.tools, undefined, 2)}
-              onChange={(e) => {
-                onChange('tools', JSON.parse(e.currentTarget.value));
-              }}
+            <JsonEditor
+              data={nodeParameters.tools || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleToolsChange}
+              onAdd={handleToolsChange}
+              onDelete={handleToolsChange}
             />
             <small className="form-text text-muted">Tools configuration as JSON.</small>
           </div>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/HuggingFaceChatModelNodeConfigureForm.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/HuggingFaceChatModelNodeConfigureForm.js
@@ -1,9 +1,20 @@
+/**
+ * @author Petteri Karttunen
+ * @author Louis-Guillaume Durand
+ */
 import React from 'react';
+
+import { JsonEditor } from 'json-edit-react';
 
 import { Tab, Tabs } from '../../ui/Tabs';
 
 const HuggingFaceChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
   const rangeWidth = nodeParameters.temperature * 100;
+
+  const handleToolsChange = ({ newData }) => {
+    onChange('tools', newData);
+  };
+
   return (
     <Tabs>
       <Tab id={'generalSettings'} label={'General Settings'}>
@@ -200,14 +211,15 @@ const HuggingFaceChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => 
         <div>
           <div className="form-group">
             <label htmlFor="tools">Tools</label>
-            <textarea
-              className="form-control"
-              id="tools"
-              rows="20"
-              value={JSON.stringify(nodeParameters.tools, undefined, 2)}
-              onChange={(e) => {
-                onChange('tools', JSON.parse(e.currentTarget.value));
-              }}
+            <JsonEditor
+              data={nodeParameters.tools || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleToolsChange}
+              onAdd={handleToolsChange}
+              onDelete={handleToolsChange}
             />
             <small className="form-text text-muted">Tools configuration as JSON.</small>
           </div>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/MistralAIChatModelNodeConfigureForm.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/MistralAIChatModelNodeConfigureForm.js
@@ -1,12 +1,20 @@
 /**
  * @author Petteri Karttunen
+ * @author Louis-Guillaume Durand
  */
 import React from 'react';
+
+import { JsonEditor } from 'json-edit-react';
 
 import { Tab, Tabs } from '../../ui/Tabs';
 
 const OpenAIChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
   const rangeWidth = nodeParameters.temperature * 100;
+
+  const handleToolsChange = ({ newData }) => {
+    onChange('tools', newData);
+  };
+
   return (
     <Tabs>
       <Tab id={'generalSettings'} label={'General Settings'}>
@@ -243,14 +251,15 @@ const OpenAIChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
         <div>
           <div className="form-group">
             <label htmlFor="tools">Tools</label>
-            <textarea
-              className="form-control"
-              id="tools"
-              rows="20"
-              value={JSON.stringify(nodeParameters.tools, undefined, 2)}
-              onChange={(e) => {
-                onChange('tools', JSON.parse(e.currentTarget.value));
-              }}
+            <JsonEditor
+              data={nodeParameters.tools || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleToolsChange}
+              onAdd={handleToolsChange}
+              onDelete={handleToolsChange}
             />
             <small className="form-text text-muted">Tools configuration as JSON.</small>
           </div>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/OllamaChatModelNodeConfigureForm.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/OllamaChatModelNodeConfigureForm.js
@@ -1,12 +1,20 @@
 /**
  * @author Petteri Karttunen
+ * @author Louis-Guillaume Durand
  */
 import React from 'react';
+
+import { JsonEditor } from 'json-edit-react';
 
 import { Tab, Tabs } from '../../ui/Tabs';
 
 const OllamaChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
   const rangeWidth = nodeParameters.temperature * 100;
+
+  const handleToolsChange = ({ newData }) => {
+    onChange('tools', newData);
+  };
+
   return (
     <Tabs>
       <Tab id={'generalSettings'} label={'General Settings'}>
@@ -271,14 +279,15 @@ const OllamaChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
         <div>
           <div className="form-group">
             <label htmlFor="tools">Tools</label>
-            <textarea
-              className="form-control"
-              id="tools"
-              rows="20"
-              value={JSON.stringify(nodeParameters.tools, undefined, 2)}
-              onChange={(e) => {
-                onChange('tools', JSON.parse(e.currentTarget.value));
-              }}
+            <JsonEditor
+              data={nodeParameters.tools || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleToolsChange}
+              onAdd={handleToolsChange}
+              onDelete={handleToolsChange}
             />
             <small className="form-text text-muted">Tools configuration as JSON.</small>
           </div>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/OpenAIChatModelNodeConfigureForm.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/OpenAIChatModelNodeConfigureForm.js
@@ -1,12 +1,20 @@
 /**
  * @author Petteri Karttunen
+ * @author Louis-Guillaume Durand
  */
 import React from 'react';
+
+import { JsonEditor } from 'json-edit-react';
 
 import { Tab, Tabs } from '../../ui/Tabs';
 
 const OpenAIChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
   const rangeWidth = nodeParameters.temperature * 100;
+
+  const handleToolsChange = ({ newData }) => {
+    onChange('tools', newData);
+  };
+
   return (
     <Tabs>
       <Tab id={'generalSettings'} label={'General Settings'}>
@@ -289,14 +297,15 @@ const OpenAIChatModelNodeConfigureForm = ({ nodeParameters, onChange }) => {
         <div>
           <div className="form-group">
             <label htmlFor="tools">Tools</label>
-            <textarea
-              className="form-control"
-              id="tools"
-              rows="20"
-              value={JSON.stringify(nodeParameters.tools, undefined, 2)}
-              onChange={(e) => {
-                onChange('tools', JSON.parse(e.currentTarget.value));
-              }}
+            <JsonEditor
+              data={nodeParameters.tools || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleToolsChange}
+              onAdd={handleToolsChange}
+              onDelete={handleToolsChange}
             />
             <small className="form-text text-muted">Tools configuration as JSON.</small>
           </div>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/WebhookNodeConfigureForm.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/flow/forms/WebhookNodeConfigureForm.js
@@ -1,11 +1,22 @@
 /**
  * @author Petteri Karttunen
+ * @author Louis-Guillaume Durand
  */
 import React from 'react';
+
+import { JsonEditor } from 'json-edit-react';
 
 import { Tab, Tabs } from '../../ui/Tabs';
 
 const WebhookNodeConfigureForm = ({ nodeParameters, onChange }) => {
+  const handleBodyChange = ({ newData }) => {
+    onChange('body', newData);
+  };
+
+  const handleHeadersChange = ({ newData }) => {
+    onChange('headers', newData);
+  };
+
   return (
     <Tabs>
       <Tab id={'generalSettings'} label={'General Settings'}>
@@ -48,27 +59,29 @@ const WebhookNodeConfigureForm = ({ nodeParameters, onChange }) => {
         <div>
           <div className="form-group">
             <label htmlFor="body">Body JSON</label>
-            <textarea
-              className="form-control"
-              id="body"
-              rows="3"
-              onChange={(e) => {
-                onChange('body', JSON.parse(e.currentTarget.value));
-              }}
-              value={JSON.stringify(nodeParameters.body, undefined, 2)}
+            <JsonEditor
+              data={nodeParameters.body || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleBodyChange}
+              onAdd={handleBodyChange}
+              onDelete={handleBodyChange}
             />
             <small className="form-text text-muted">Enter the body payload as JSON.</small>
           </div>
           <div className="form-group">
             <label htmlFor="headers">Headers JSON</label>
-            <textarea
-              className="form-control"
-              id="headers"
-              rows="3"
-              onChange={(e) => {
-                onChange('headers', JSON.parse(e.currentTarget.value));
-              }}
-              value={JSON.stringify(nodeParameters.headers, undefined, 2)}
+            <JsonEditor
+              data={nodeParameters.headers || {}}
+              indent={2}
+              collapse={2}
+              collapseAnimationTime={150}
+              maxWidth={'100%'}
+              onEdit={handleHeadersChange}
+              onAdd={handleHeadersChange}
+              onDelete={handleHeadersChange}
             />
             <small className="form-text text-muted">Enter the headers as JSON.</small>
           </div>


### PR DESCRIPTION
Leverage the JSON editor used for the whole graph as the editor for some node JSON parameters such as body, headers and tools.

Closes #26

![Screenshot_20250218_205055](https://github.com/user-attachments/assets/49f41cd9-22e5-4a24-972a-0246fdfccfd0)
