### PR TITLE
feat(admin-web): add enable/disable option to task edit

### DIFF
--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/AITaskAdd.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/AITaskAdd.js
@@ -4,7 +4,6 @@
 import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
-import { JsonEditor } from 'json-edit-react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ROUTE_TASK_LIST } from '../constants/AITasksRoutesConstants';
@@ -37,7 +36,7 @@ const AITaskAdd = () => {
       value = value.trim().replaceAll(' ', '');
     }
     if (name === 'enabled') {
-      value = JSON.parse(value);
+      value = !formData.enabled;
     }
     setFormData((prevFormData) => ({
       ...prevFormData,
@@ -138,7 +137,9 @@ const AITaskAdd = () => {
           </div>
           <div className="form-group">
             <label className="toggle-switch">
-              <span className="toggle-switch-label">Enabled</span>
+              <span className="toggle-switch-label">
+                {formData.enabled ? 'Enabled' : 'Disabled'}
+              </span>
               <span className="toggle-switch-check-bar">
                 <input
                   id="enabled"

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/AITaskEdit.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/AITaskEdit.js
@@ -49,6 +49,9 @@ const AITaskEdit = () => {
     if (name === 'externalReferenceCode') {
       value = value.trim().replaceAll(' ', '');
     }
+    if (name === 'enabled') {
+      value = JSON.parse(value);
+    }
     const updatedTask = {
       ...selectedTask,
       [name]: value,
@@ -61,7 +64,8 @@ const AITaskEdit = () => {
     const currentSavedTask = await fetchTask(selectedTask.id);
     if (
       currentSavedTask.title !== selectedTask.title ||
-      currentSavedTask.externalReferenceCode !== selectedTask.externalReferenceCode
+      currentSavedTask.externalReferenceCode !== selectedTask.externalReferenceCode ||
+      currentSavedTask.enabled !== selectedTask.enabled
     ) {
       updateTask(selectedTask);
     }
@@ -128,7 +132,7 @@ const AITaskEdit = () => {
               type={'text'}
               value={selectedTask.externalReferenceCode}
               onChange={handleInputOnChange}
-              onBlur={(e) => {
+              onBlur={() => {
                 handleBasicInfoChanges();
               }}
               onKeyDown={(e) => {
@@ -140,15 +144,49 @@ const AITaskEdit = () => {
           </div>
         </div>
         <div slot="right">
-          <button
-            className={'btn btn-secondary'}
-            onClick={(e) => {
-              e.preventDefault();
-              setIsChatPreviewOpen(!isChatPreviewOpen);
-            }}
-          >
-            {(isChatPreviewOpen ? 'Close' : 'Open') + ' Chat Preview'}
-          </button>
+          <div className="form-group-autofit mb-0 mt-3">
+            <div className="form-group-item">
+              <label className="toggle-switch">
+                <span className="toggle-switch-label">
+                  {selectedTask.enabled ? 'Enabled' : 'Disabled'}
+                </span>
+                <span className="toggle-switch-check-bar">
+                  <input
+                    id="enabled"
+                    name="enabled"
+                    className="toggle-switch-check"
+                    role="switch"
+                    type="checkbox"
+                    value={selectedTask.enabled}
+                    defaultChecked={selectedTask.enabled}
+                    onChange={() => {
+                      console.log(!selectedTask.enabled);
+                      const updatedTask = {
+                        ...selectedTask,
+                        enabled: !selectedTask.enabled,
+                      };
+                      setSelectedTask(updatedTask);
+                      updateTask(updatedTask);
+                    }}
+                  />
+                  <span aria-hidden="true" className="toggle-switch-bar">
+                    <span className="toggle-switch-handle"></span>
+                  </span>
+                </span>
+              </label>
+            </div>
+            <div className="form-group-item">
+              <button
+                className={'btn btn-sm btn-secondary'}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsChatPreviewOpen(!isChatPreviewOpen);
+                }}
+              >
+                {(isChatPreviewOpen ? 'Close' : 'Open') + ' Chat Preview'}
+              </button>
+            </div>
+          </div>
         </div>
       </NavigationBar>
       <div className={'sheet sheet-xl mt-6 px-0'}>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/AITaskList.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/components/AITaskList.js
@@ -10,6 +10,7 @@ import { getFormattedUTC } from '../utils/dateUtils';
 import Alert from './ui/Alert';
 import EmptyState from './ui/EmptyState';
 import Icon from './ui/Icon';
+import Label from './ui/Label';
 import LoadingIndicator from './ui/LoadingIndicator';
 import NavigationBar from './ui/NavigationBar';
 import Toast from './ui/Toast';
@@ -128,6 +129,7 @@ const AITaskList = () => {
                 <th>Title</th>
                 <th>ID</th>
                 <th>Endpoint</th>
+                <th>Status</th>
                 <th>Version</th>
                 <th>Actions</th>
               </tr>
@@ -143,6 +145,13 @@ const AITaskList = () => {
                   <td>{task.id}</td>
                   <td>
                     <code>{'/o/ai-tasks/v1.0/generate/' + task.externalReferenceCode}</code>
+                  </td>
+                  <td>
+                    {task.enabled ? (
+                      <Label type={'success'}>Enabled</Label>
+                    ) : (
+                      <Label type={'warning'}>Disabled</Label>
+                    )}
                   </td>
                   <td>{task.version}</td>
                   <td>

--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/contexts/AITasksContext.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/contexts/AITasksContext.js
@@ -46,7 +46,7 @@ const AITasksProvider = ({ children }) => {
   const fetchTasks = async () => {
     try {
       const data = await LiferayService.get(
-        `/o/ai-tasks/v1.0/ai-tasks?fields=id,title,externalReferenceCode,version`,
+        `/o/ai-tasks/v1.0/ai-tasks?fields=id,title,externalReferenceCode,version,enabled`,
       );
       return data.items;
     } catch (error) {


### PR DESCRIPTION
Add the option to enable/disable a task from the edition view. Also fix an issue with the enable/disable option on the add view. Finally, add a new column in the task list to see the enable/disable status.

Closes #20

![Screenshot_20250218_211939](https://github.com/user-attachments/assets/4e5a48ad-d4d0-411a-b1b2-6700819690f8)
![Screenshot_20250218_211946](https://github.com/user-attachments/assets/a0e0a24a-8ef1-457d-bcc5-b86ead67b0b5)
![Screenshot_20250218_212042](https://github.com/user-attachments/assets/feeca477-5d8e-48ae-aafa-202a7042824e)
