### PR TITLE
feat: add better support for reasoning models

### DIFF
--- a/liferay-workspace/client-extensions/ai-tasks-admin-web/src/hooks/useChatHistory.js
+++ b/liferay-workspace/client-extensions/ai-tasks-admin-web/src/hooks/useChatHistory.js
@@ -14,8 +14,8 @@ function useChatHistory(taskId) {
     localStorage.setItem(chatKey, JSON.stringify(history));
   }, [chatKey, history]);
 
-  const addMessage = (text, role, debug) => {
-    const newMessage = { text, role, debug };
+  const addMessage = (text, role, debug, think) => {
+    const newMessage = { text, role, debug, think };
     setHistory((prevHistory) => [...prevHistory, newMessage]);
   };
 

--- a/liferay-workspace/modules/ai-tasks-service/build.gradle
+++ b/liferay-workspace/modules/ai-tasks-service/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 	compileInclude group: "org.eclipse.collections", name: "eclipse-collections-api", version: "11.1.0"
 	compileInclude group: "org.jetbrains.kotlin", name: "kotlin-stdlib", version: "1.9.24"
 	compileInclude group: "org.json", name: "json", version: "20231013"
+	compileInclude group: "org.jsoup", name: "jsoup", version: "1.18.3"
 	compileInclude group: "org.lz4", name: "lz4-java", version: "1.8.0"
 	compileInclude group: "org.mapdb", name: "elsa", version: "3.0.0-M5"
 	compileInclude group: "org.mapdb", name: "mapdb", version: "3.1.0"

--- a/liferay-workspace/modules/ai-tasks-service/src/main/java/fi/soveltia/liferay/aitasks/internal/task/node/BaseAITaskNode.java
+++ b/liferay-workspace/modules/ai-tasks-service/src/main/java/fi/soveltia/liferay/aitasks/internal/task/node/BaseAITaskNode.java
@@ -13,6 +13,9 @@ import dev.langchain4j.service.Result;
 import fi.soveltia.liferay.aitasks.task.context.AITaskContext;
 import fi.soveltia.liferay.aitasks.task.context.AITaskContextParameter;
 import fi.soveltia.liferay.aitasks.task.node.AITaskNodeResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,6 +47,8 @@ public abstract class BaseAITaskNode {
 		AITaskContext aiTaskContext, boolean debug,
 		Map<String, Object> debugInfo, JSONObject jsonObject, Object value) {
 
+		Object think = null;
+
 		if (value == null) {
 			return new AITaskNodeResponseImpl(debugInfo, null);
 		}
@@ -56,6 +61,12 @@ public abstract class BaseAITaskNode {
 
 		if (value instanceof String) {
 			value = StringUtil.trim((String)value);
+			Document document = Jsoup.parse((String) value);
+			Elements thinkElement = document.select("think");
+			if(thinkElement.size() == 1) {
+				think = thinkElement.get(0).text();
+                value = ((String) value).split("</think>")[1];
+			}
 		}
 
 		String taskContextOutputParameterName = jsonObject.getString(
@@ -68,7 +79,7 @@ public abstract class BaseAITaskNode {
 				debugInfo,
 				HashMapBuilder.put(
 					jsonObject.getString("outputParameterName", "text"), value
-				).build());
+				).put("think", think).build());
 		}
 
 		aiTaskContext.addAITaskContextParameter(


### PR DESCRIPTION
- Add a new output "think" if those tags are found in the AI response, and remove the thoughts from the "text" output.
- Add a new collapsable area named "Thoughts" that separate the actual response from the thinking process.

API response example:
```json
{
    "debugInfo": {
    },
    "output": {
        "think": "Alright, so I'm looking for some...",
        "text": "\n\nCertainly! Here's a thoughtfully..."
    },
    "took": "16695ms"
}
```

UX/UI example:

![Screenshot_20250218_235350](https://github.com/user-attachments/assets/1467b3c3-ab07-40b0-9f18-d343430e2e9f)
![Screenshot_20250218_235432](https://github.com/user-attachments/assets/bf0f743f-e013-4776-822d-f974307e3fd0)


Closes #11